### PR TITLE
fix: typo

### DIFF
--- a/books/learn-react-with-jotai/suspense-basics.md
+++ b/books/learn-react-with-jotai/suspense-basics.md
@@ -28,7 +28,7 @@ const [isLoading, setIsLoading] = useState(false);
 ```tsx
 const UserProfile: React.FC<{ userPromise: Promise<User> }> = ({ userPromise }) => {
   // useでPromiseの中身を取り出す
-  const user: User = use(userProfile);
+  const user: User = use(userPromise);
 
   return <section>
     <h1>{user.name}のプロフィール</h1>


### PR DESCRIPTION
『jotaiによるReact再入門』Chapter 03の最初のサンプルコードで、`userPromise`が`userProfile`になっていたため修正しました🙇